### PR TITLE
Support materials

### DIFF
--- a/FreecadParametricFEA/freecadmodel.py
+++ b/FreecadParametricFEA/freecadmodel.py
@@ -71,11 +71,20 @@ class FreecadModel:
                 raise
 
         # FIXME: this should really be done via type checking
+
+
         try:
-            is_sketch = str(target_object[0]) == "<Sketcher::SketchObject>"
-            if is_sketch:
+            target_str = str(target_object[0])
+            is_sketch = False
+            if target_str == "<Sketcher::SketchObject>":
+                is_sketch = True
                 target_object[0].getDatum(constraint_name)
                 logger.debug(f"Object {object_name} is a sketch, found {constraint_name}")
+            elif target_str == "<App::MaterialObjectPython object>":
+                from materialtools.cardutils import import_materials as getmats
+                materials, _, _ = getmats(target_object[0].Category)
+
+                logger.debug(f"Object {object_name} is a material, setting material {constraint_name}")
             else:
                 getattr(target_object[0], constraint_name)
                 logger.debug(

--- a/FreecadParametricFEA/freecadmodel.py
+++ b/FreecadParametricFEA/freecadmodel.py
@@ -78,7 +78,7 @@ class FreecadModel:
 
         try:
             target_str = str(target_object[0])
-            
+
             # sketcher objects need obj.getDatum / obj.setDatum
             if target_str == "<Sketcher::SketchObject>":
                 target_object[0].getDatum(constraint_name)
@@ -91,15 +91,21 @@ class FreecadModel:
                 from materialtools.cardutils import import_materials as getmats
                 materials, _, _ = getmats(target_object[0].Category)
 
-                logger.debug(f"Object {object_name} is a material, setting material {constraint_name}")
-            
+                for (_, m) in materials.items():
+                    if m["CardName"] == target_value:
+                        target_object[0].Material = m
+                        return
+
+                logger.debug(f"Object {object_name} is a material, "
+                             "setting material {constraint_name}")
+
             # generic objects need setattr(obj, attr, value)
             else:
                 getattr(target_object[0], constraint_name)
                 logger.debug(
                     f"Object {object_name} is an object, found {constraint_name}"
                     )
-                
+
                 setattr(target_object[0], constraint_name, target_value)
 
         except (NameError, IndexError):
@@ -107,9 +113,6 @@ class FreecadModel:
                 f"Invalid constraint name {constraint_name} in object {object_name}"
             )
             raise
-
-        # set the datum to the desired value.
-
 
         logger.debug(f"Set {object_name}.{constraint_name} to {target_value}")
         # apply changes and recompute
@@ -172,7 +175,7 @@ class FreecadModel:
             objects = []
             objects.append(self.model.getObject(self.fea_results_name))
             vtkResults.importVTKResults.export(objects, filename)
-            logger.info("Exporting VTK file {filename}")
+            logger.info(f"Exporting VTK file {filename}")
             del objects
         else:
             try:

--- a/FreecadParametricFEA/parametric.py
+++ b/FreecadParametricFEA/parametric.py
@@ -251,6 +251,9 @@ class parametric:
         param_headings = []
         output_headings = []
 
+        # if parameter["constraint_values"] is a string, we need to map it 
+        # to a dict of integers so that meshgrid still works. After meshgrid
+        # we then need to replace. Maybe use pd.category??? could this work?
         for parameter in variables:
             param_vals.append(parameter["constraint_values"])
             param_headings.append(self._param_to_df_heading(parameter))

--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ fea.set_outputs([
     ])
 ```
 
+### Changing materials
+You can specify any material that you can find in the FreeCAD FEA material selection dropdown; just refer to it by its name:
+
+```python
+fea.set_outputs([
+    {
+        "object_name": "MaterialSolid",  # the object where to find the constraint
+        "constraint_name": "Material",  # the constraint name that you assigned
+        "constraint_values": ["Aluminium-Generic", "Steel-Generic"],
+    },
+])
+```
+
+
 ### Exporting data
 
 You can export individual ParaView files using:

--- a/examples/hole/optimize.py
+++ b/examples/hole/optimize.py
@@ -17,8 +17,13 @@ fea.set_variables(
             "object_name": "Sketch",  # the object where to find the constraint
             "constraint_name": "HoleDiam",  # the constraint name that you assigned
             "constraint_values": np.linspace(
-                10, 30, 5
+                10, 30, 2
             ),  # the values you want to check
+        },
+        {
+            "object_name": "MaterialSolid",  # the object where to find the constraint
+            "constraint_name": "Material",  # the constraint name that you assigned
+            "constraint_values": ["Aluminium-Generic", "Steel-Generic"],
         },
     ]
 )


### PR DESCRIPTION
Add support for parametrising materials. Needed a bit of restructuring of `parametric.populate_test_dataframe()` and a special case handling in `freecadmodel.change_parameter()`

Fix #20 